### PR TITLE
Build OpenMP and clang-tools-extra

### DIFF
--- a/.github/scripts/build_llvm.sh
+++ b/.github/scripts/build_llvm.sh
@@ -25,6 +25,7 @@ cmake -G Ninja -S "$LLVMROOT"/llvm -B "$BUILD_DIR" \
             -DLLVM_ENABLE_TERMINFO=OFF \
             -DLLVM_ENABLE_PROJECTS="llvm;clang;lld;clang-tools-extra;openmp" \
             -DLLVM_USE_RELATIVE_PATHS_IN_FILES=ON \
+            -DCLANG_ENABLE_CLANGD=OFF \
             -DCLANG_DEFAULT_LINKER=lld \
             -DCLANG_VENDOR=Tenjin \
             -DCPACK_GENERATOR=TXZ \

--- a/.github/scripts/build_llvm.sh
+++ b/.github/scripts/build_llvm.sh
@@ -23,7 +23,7 @@ cmake -G Ninja -S "$LLVMROOT"/llvm -B "$BUILD_DIR" \
             -DLLVM_ENABLE_CURL=OFF \
             -DLLVM_ENABLE_HTTPLIB=OFF \
             -DLLVM_ENABLE_TERMINFO=OFF \
-            -DLLVM_ENABLE_PROJECTS="llvm;clang;lld" \
+            -DLLVM_ENABLE_PROJECTS="llvm;clang;lld;clang-tools-extra;openmp" \
             -DLLVM_USE_RELATIVE_PATHS_IN_FILES=ON \
             -DCLANG_DEFAULT_LINKER=lld \
             -DCLANG_VENDOR=Tenjin \


### PR DESCRIPTION
OpenMP is intended for use when building other tools (like Souffle and Z3). Enabling `clang-tools-extra` is required to build our `clang-refold` tool.